### PR TITLE
Add mirroring workflow to Github Action CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -102,3 +102,38 @@ jobs:
         run: npm test -- --verbose
         env:
           CI: true
+
+  mirror:
+    needs: [test, prettier, eslint]
+    runs-on: ubuntu-latest
+    if: github.ref == 'refs/heads/main'
+    env:
+      MIRROR_REPO: ${{ secrets.MIRROR_REPO }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Configure Git
+        run: |
+          git config --global user.name "GitHub Actions"
+          git config --global user.email "actions@github.com"
+
+      - name: Setup SSH
+        run: |
+          mkdir -p ~/.ssh
+          echo "${{ secrets.SSH_PRIVATE_KEY }}" > ~/.ssh/id_rsa
+          chmod 600 ~/.ssh/id_rsa
+          ssh-keyscan -H github.com >> ~/.ssh/known_hosts
+
+      - name: Check if not mirror
+        run: |
+          if [ "$GITHUB_REPOSITORY" = "$MIRROR_REPO" ]; then
+            echo "Already on mirror repository, skipping push"
+            exit 0
+          fi
+
+      - name: Push to mirror
+        run: |
+          git remote add mirror git@github.com:${{ secrets.MIRROR_REPO }}.git
+          git push mirror main


### PR DESCRIPTION
This commit introduces a new job in the CI workflow that pushes changes to a mirror repository on the main branch. It includes steps for configuring Git, setting up SSH, and checking if the current repository is the mirror before pushing.